### PR TITLE
Add `extern "C"` guards for use in C++ projects

### DIFF
--- a/include/RA8875.h
+++ b/include/RA8875.h
@@ -3,6 +3,10 @@
 #include <stdint.h>
 #include "driver/spi_master.h"
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 typedef struct {
 
     spi_device_handle_t spi_device;
@@ -120,7 +124,7 @@ void RA8875_set_writing_layer(RA8875_context_t* ctx, uint8_t layer);
     1100b S
     1101b S+~D
     1110b S+D
-    1111b 1 ( Whiteness ) 
+    1111b 1 ( Whiteness )
 
 */
 
@@ -140,3 +144,7 @@ void RA8875_bte_move(RA8875_context_t* ctx, uint16_t srcX, uint16_t srcY, uint8_
 /// Fills a rectangle on the display.
 /// </summary>
 void RA8875_bte_fill(RA8875_context_t* ctx, uint16_t x, uint16_t y, uint8_t layer, uint16_t width, uint16_t height, uint8_t color);
+
+#if defined(__cplusplus)
+}
+#endif

--- a/include/RA8875.h
+++ b/include/RA8875.h
@@ -148,3 +148,4 @@ void RA8875_bte_fill(RA8875_context_t* ctx, uint16_t x, uint16_t y, uint8_t laye
 #if defined(__cplusplus)
 }
 #endif
+


### PR DESCRIPTION
Just added these guard preprocessor blocks. Otherwise, C++ projects that try to use your library will get unresolved symbols at link time.

I've been really frustrated with the RA8875. I can't get it to draw faster than about 1/10th frame per second with the Adafruit driver library.

I've got yours rendering rectangles rather quickly, so that's a move in the right direction; I'll just have to see what you do differently in the setup/communication with the display and fix the Adafruit version.